### PR TITLE
CI: coverage now needs PIP_AGS set in its own job. 

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,5 +1,5 @@
 pip==25.2
-nox==2025.5.1
+nox==2024.4.15
 nox-poetry==1.0.3
-poetry==1.8.1
+poetry==1.8.5
 virtualenv==20.33.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
         include:
           - { python: "3.12", os: "ubuntu-latest", session: "pre-commit" }
           #- { python: "3.12", os: "ubuntu-latest", session: "mypy" }
-          # - { python: "3.11", os: "ubuntu-latest", session: "tests" }
+          - { python: "3.11", os: "ubuntu-latest", session: "tests" }
           - { python: "3.12", os: "ubuntu-latest", session: "tests", coverage: true}
           # - { python: "3.12", os: "windows-latest", session: "tests" }
           # - { python: "3.12", os: "macos-latest", session: "tests" }
@@ -31,7 +31,7 @@ jobs:
       ###############################
       # Work around pipx issue #1331 with absolute path to constraint.txt
       # https://github.com/pypa/pipx/issues/1331#issuecomment-2043163012
-      - name: Set PIP_ARGS
+      - name: Set PIP_ARGS on Windows
         run: echo "PIP_ARGS=--constraint=$env:GITHUB_WORKSPACE/.github/workflows/constraints.txt" | Out-File -FilePath $env:GITHUB_ENV -Append
         if: runner.os == 'Windows'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
         include:
           - { python: "3.12", os: "ubuntu-latest", session: "pre-commit" }
           #- { python: "3.12", os: "ubuntu-latest", session: "mypy" }
-          - { python: "3.11", os: "ubuntu-latest", session: "tests" }
+          # - { python: "3.11", os: "ubuntu-latest", session: "tests" }
           - { python: "3.12", os: "ubuntu-latest", session: "tests", coverage: true}
           # - { python: "3.12", os: "windows-latest", session: "tests" }
           # - { python: "3.12", os: "macos-latest", session: "tests" }
@@ -147,6 +147,7 @@ jobs:
 
       - name: Install Poetry
         run: |
+          echo "PIP_ARGS: ${{ env.PIP_ARGS }}"
           pipx install --pip-args=${{ env.PIP_ARGS }} poetry
           poetry --version
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,6 +132,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: tests
     steps:
+      ###############################
+      # Work around pipx issue #1331 with absolute path to constraint.txt
+      # https://github.com/pypa/pipx/issues/1331#issuecomment-2043163012
+      - name: Set PIP_ARGS on Windows
+        run: echo "PIP_ARGS=--constraint=$env:GITHUB_WORKSPACE/.github/workflows/constraints.txt" | Out-File -FilePath $env:GITHUB_ENV -Append
+        if: runner.os == 'Windows'
+
+      - name: Set PIP_ARGS on not-Windows
+        run: echo "PIP_ARGS=--constraint=$GITHUB_WORKSPACE/.github/workflows/constraints.txt" >> "$GITHUB_ENV"
+        if: runner.os != 'Windows'
+      ###############################
+
       - name: Check out the repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       ###############################
       # Work around pipx issue #1331 with absolute path to constraint.txt
       # https://github.com/pypa/pipx/issues/1331#issuecomment-2043163012
-      - name: Set PIP_ARGS on Windows
+      - name: Set PIP_ARGS
         run: echo "PIP_ARGS=--constraint=$env:GITHUB_WORKSPACE/.github/workflows/constraints.txt" | Out-File -FilePath $env:GITHUB_ENV -Append
         if: runner.os == 'Windows'
 
@@ -159,7 +159,6 @@ jobs:
 
       - name: Install Poetry
         run: |
-          echo "PIP_ARGS: ${{ env.PIP_ARGS }}"
           pipx install --pip-args=${{ env.PIP_ARGS }} poetry
           poetry --version
 


### PR DESCRIPTION
(First discovered [here](https://github.com/SmoothStoneComputing/gridworks-proactor/commit/11d347943dc83f1308d67e64539c8ef491c3c027).